### PR TITLE
[fix] scripts/init now considers examples/*/package.json without scripts property

### DIFF
--- a/scripts/init
+++ b/scripts/init
@@ -27,11 +27,11 @@ async function main(pgPool) {
   for (const dir of examples) {
     const path = `${EXAMPLES_DIR}/${dir}`;
     const packageJson = require(`${path}/package.json`);
-    if (packageJson.scripts.before) {
+    if (packageJson.scripts && packageJson.scripts.before) {
       await run(path, "yarn", ["before"]);
     }
 
-    if (packageJson.scripts.after) {
+    if (packageJson.scripts && packageJson.scripts.after) {
       const afterScriptPath = `${path}/db/after.sql`;
       if (fs.existsSync(afterScriptPath)) {
         console.log(`# ${afterScriptPath}`);


### PR DESCRIPTION
## Description

schema_only does not contain a scripts property which causes scripts/init to fail. Updated logic to verify that a package.json contains a scripts property before accessing before/afer.

## Performance impact

none

## Security impact

none

## Checklist

- [X] My code matches the project's code style and `yarn lint:fix` passes.
